### PR TITLE
nRF52832 platform

### DIFF
--- a/src/arrow/mqtt.c
+++ b/src/arrow/mqtt.c
@@ -275,7 +275,11 @@ int mqtt_yield(int timeout_ms) {
 
 int mqtt_publish(arrow_device_t *device, void *d) {
     MQTTMessage msg;
+#if defined(__nrf52832__)
+    msg.qos = QOS1;
+#else
     msg.qos = QOS0;
+#endif
     msg.retained = 0;
     msg.dup = 0;
     char *payload = telemetry_serialize(device, d);

--- a/src/wolfSSL/user_settings.h
+++ b/src/wolfSSL/user_settings.h
@@ -300,6 +300,67 @@
     #define XGMTIME localtime
 #endif
 
+#elif defined(__nrf52832__)
+#define WOLFSSL_USER_IO
+#define NO_WRITEV
+#define NO_DEV_RANDOM
+#define NO_WOLFSSL_DIR
+#define NO_SHA512
+#define NO_DH
+#define NO_DSA
+//#define NO_RSA
+#define NO_RC4
+#define NO_DES
+#define NO_DES3
+#define NO_RABBIT
+//#define NO_AES
+#define NO_ECC256
+#define HAVE_ECC
+//#define NO_ECC_DHE
+#define NO_HC128
+#define NO_PSK
+#define NO_MD2
+#define NO_MD4
+//#define NO_MD5
+#define NO_OLD_TLS
+#define NO_PWDBASED
+#define NO_SKID
+//#define NO_CURVE25519
+//#define NO_ED25519
+
+#define WOLFSSL_STATIC_RSA
+#define NO_WOLFSSL_SERVER
+//#define NO_CERTS
+#define SINGLE_THREADED
+#define NO_STDIO_FILESYSTEM
+//#define CTYPE_USER
+//#define XMALLOC_USER
+//#define SHA256_DIGEST_SIZE 32
+#define WOLFSSL_BASE64_ENCODE
+//#define DEBUG_WOLFSSL
+//#define HAVE_SUPPORTED_CURVES
+//#define HAVE_TLS_EXTENSIONS
+//#define SIZEOF_LONG_LONG  8
+/* Options for Sample program */
+#define NO_SESSION_CACHE // For Small RAM
+#define WOLFSSL_LOW_MEMORY
+//#define WOLFSSL_SMALL_STACK
+#define TFM_TIMING_RESISTANT
+#define RSA_LOW_MEM
+//#define USE_CYASSL_MEMORY
+#define NO_WOLFSSL_MEMORY
+//#define STATIC_CHUNKS_ONLY
+//#define LARGE_STATIC_BUFFERS
+#define WOLFSSL_NO_VERIFYSERVER
+#define NO_FILESYSTEM
+#define NO_CERT
+#define HAVE_TM_TYPE
+#ifndef WOLFSSL_NO_VERIFYSERVER
+    #define TIME_OVERRIDES
+    #define XTIME time
+    #define XGMTIME localtime
+#endif
+
 #elif defined(__quadro__)
 #define WOLFSSL_USER_IO
 #define NO_ERROR_STRINGS
@@ -402,67 +463,6 @@
 //#define NO_WOLFSSL_MEMORY
 //#define STATIC_CHUNKS_ONLY
 #define LARGE_STATIC_BUFFERS
-#define WOLFSSL_NO_VERIFYSERVER
-#define NO_FILESYSTEM
-#define NO_CERT
-#define HAVE_TM_TYPE
-#ifndef WOLFSSL_NO_VERIFYSERVER
-    #define TIME_OVERRIDES
-    #define XTIME time
-    #define XGMTIME localtime
-#endif
-
-#elif defined(__nrf52832__)
-#define WOLFSSL_USER_IO
-#define NO_WRITEV
-#define NO_DEV_RANDOM
-#define NO_WOLFSSL_DIR
-#define NO_SHA512
-#define NO_DH
-#define NO_DSA
-//#define NO_RSA
-#define NO_RC4
-#define NO_DES
-#define NO_DES3
-#define NO_RABBIT
-//#define NO_AES
-#define NO_ECC256
-#define HAVE_ECC
-//#define NO_ECC_DHE
-#define NO_HC128
-#define NO_PSK
-#define NO_MD2
-#define NO_MD4
-//#define NO_MD5
-#define NO_OLD_TLS
-#define NO_PWDBASED
-#define NO_SKID
-//#define NO_CURVE25519
-//#define NO_ED25519
-
-#define WOLFSSL_STATIC_RSA
-#define NO_WOLFSSL_SERVER
-//#define NO_CERTS
-#define SINGLE_THREADED
-#define NO_STDIO_FILESYSTEM
-//#define CTYPE_USER
-//#define XMALLOC_USER
-//#define SHA256_DIGEST_SIZE 32
-#define WOLFSSL_BASE64_ENCODE
-//#define DEBUG_WOLFSSL
-//#define HAVE_SUPPORTED_CURVES
-//#define HAVE_TLS_EXTENSIONS
-//#define SIZEOF_LONG_LONG  8
-/* Options for Sample program */
-#define NO_SESSION_CACHE // For Small RAM
-#define WOLFSSL_LOW_MEMORY
-//#define WOLFSSL_SMALL_STACK
-#define TFM_TIMING_RESISTANT
-#define RSA_LOW_MEM
-//#define USE_CYASSL_MEMORY
-#define NO_WOLFSSL_MEMORY
-//#define STATIC_CHUNKS_ONLY
-//#define LARGE_STATIC_BUFFERS
 #define WOLFSSL_NO_VERIFYSERVER
 #define NO_FILESYSTEM
 #define NO_CERT

--- a/src/wolfSSL/user_settings.h
+++ b/src/wolfSSL/user_settings.h
@@ -411,6 +411,68 @@
     #define XTIME time
     #define XGMTIME localtime
 #endif
+
+#elif defined(__nrf52832__)
+#define WOLFSSL_USER_IO
+#define NO_WRITEV
+#define NO_DEV_RANDOM
+#define NO_WOLFSSL_DIR
+#define NO_SHA512
+#define NO_DH
+#define NO_DSA
+//#define NO_RSA
+#define NO_RC4
+#define NO_DES
+#define NO_DES3
+#define NO_RABBIT
+//#define NO_AES
+#define NO_ECC256
+#define HAVE_ECC
+//#define NO_ECC_DHE
+#define NO_HC128
+#define NO_PSK
+#define NO_MD2
+#define NO_MD4
+//#define NO_MD5
+#define NO_OLD_TLS
+#define NO_PWDBASED
+#define NO_SKID
+//#define NO_CURVE25519
+//#define NO_ED25519
+
+#define WOLFSSL_STATIC_RSA
+#define NO_WOLFSSL_SERVER
+//#define NO_CERTS
+#define SINGLE_THREADED
+#define NO_STDIO_FILESYSTEM
+//#define CTYPE_USER
+//#define XMALLOC_USER
+//#define SHA256_DIGEST_SIZE 32
+#define WOLFSSL_BASE64_ENCODE
+//#define DEBUG_WOLFSSL
+//#define HAVE_SUPPORTED_CURVES
+//#define HAVE_TLS_EXTENSIONS
+//#define SIZEOF_LONG_LONG  8
+/* Options for Sample program */
+#define NO_SESSION_CACHE // For Small RAM
+#define WOLFSSL_LOW_MEMORY
+//#define WOLFSSL_SMALL_STACK
+#define TFM_TIMING_RESISTANT
+#define RSA_LOW_MEM
+//#define USE_CYASSL_MEMORY
+#define NO_WOLFSSL_MEMORY
+//#define STATIC_CHUNKS_ONLY
+//#define LARGE_STATIC_BUFFERS
+#define WOLFSSL_NO_VERIFYSERVER
+#define NO_FILESYSTEM
+#define NO_CERT
+#define HAVE_TM_TYPE
+#ifndef WOLFSSL_NO_VERIFYSERVER
+    #define TIME_OVERRIDES
+    #define XTIME time
+    #define XGMTIME localtime
+#endif
+
 //from <arrow_wolf_mem.h>
 #define XMALLOC_USER
 extern int rand();

--- a/src/wolfSSL/wolfcrypt/src/random.c
+++ b/src/wolfSSL/wolfcrypt/src/random.c
@@ -1456,7 +1456,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         return 0;
     }
 
-#elif defined(__stm32l475iot__) || defined(__semiconductor__) || defined(__quadro__) || defined(__silex__)
+#elif defined(__stm32l475iot__) || defined(__semiconductor__) || defined(__quadro__) || defined(__silex__) || defined(__nrf52832__)
     int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz) {
         (void)(os);
         int i;


### PR DESCRIPTION
Add support for nRF2832-based platform using a single-socket WiFi module as the interface.

Major change is setting this platform's MQTT publish QOS to 1. This forces a re-connect (usually from an HTTP to MQTT socket) when device telemetry isn't initially received. Only way, with one socket, that I could force the device to reconnect to the MQTT broker after, for example sending a "command success" HTTP POST.